### PR TITLE
Fix error causing plugin to not work with Python 3

### DIFF
--- a/octoprint_octolightHA/__init__.py
+++ b/octoprint_octolightHA/__init__.py
@@ -214,7 +214,19 @@ class OctoLightHAPlugin(
 		self.reload_settings()
 
 	def get_update_information(self):
-		return False
+		return dict(
+			octolightHA=dict(
+				displayName="OctoLightHA",
+				displayVersion=self._plugin_version,
+
+				type="github_release",
+				current=self._plugin_version,
+
+				user="mark.bloom",
+				repo="OctoLightHA",
+				pip="https://github.com/mark-bloom/OctoLight_Home-Assistant/archive/{target}.zip"
+			)
+		)
 
 	def register_custom_events(self):
 		return ["light_state_changed"]

--- a/octoprint_octolightHA/__init__.py
+++ b/octoprint_octolightHA/__init__.py
@@ -215,19 +215,6 @@ class OctoLightHAPlugin(
 
 	def get_update_information(self):
 		return False
-		 return dict(
-		 	octolightHA=dict(
-		 		displayName="OctoLightHA",
-		 		displayVersion=self._plugin_version,
-
-		 		type="github_release",
-		 		current=self._plugin_version,
-
-		 		user="mark.bloom",
-		 		repo="OctoLightHA",
-		 		pip="https://github.com/mark-bloom/OctoLight_Home-Assistant/archive/{target}.zip"
-		 	)
-		 )
 
 	def register_custom_events(self):
 		return ["light_state_changed"]


### PR DESCRIPTION
A left over `return False` and some weird indentation caused the plugin to show up as not supporting Python 3.