### PR TITLE
Add turn on/off on print state

### DIFF
--- a/octoprint_octolightHA/__init__.py
+++ b/octoprint_octolightHA/__init__.py
@@ -32,6 +32,10 @@ class OctoLightHAPlugin(
             api_key = '',
             entity_id = '',
             verify_certificate = False,
+            turnOnPrintStart = False,
+            turnOffPrintEnd = False,
+            turnOffPrintFailure = False,
+            turnOffPrintCancellation = False
         )
     
     def on_settings_initialized(self):
@@ -226,6 +230,17 @@ class OctoLightHAPlugin(
         if event == Events.CLIENT_OPENED:
             self._plugin_manager.send_plugin_message(self._identifier, dict(isLightOn=self.light_state))
             return
+        elif event == Events.PRINT_STARTED and self.config['turnOnPrintStart']:
+            if not self.light_state:
+                self.light_state = self.light_toggle()
+                self._logger.debug("PRINT_STARTED: Light state changed.")
+            return
+        elif (event == Events.PRINT_DONE and self.config['turnOffPrintEnd']) or (event == Events.PRINT_FAILED and self.config['turnOffPrintFailure']) or (event == Events.PRINT_CANCELLED and self.config['turnOffPrintCancellation']):
+            if self.light_state:
+                self.light_state = self.light_toggle()
+                self._logger.debug("PRINT_DONE: Light state changed.")
+            return
+        
 
     def on_settings_save(self, data):
         octoprint.plugin.SettingsPlugin.on_settings_save(self, data)

--- a/octoprint_octolightHA/templates/octolightHA_settings.jinja2
+++ b/octoprint_octolightHA/templates/octolightHA_settings.jinja2
@@ -34,4 +34,28 @@
             <!-- /ko -->
         </div>
     </div>
+    <div class="control-group">
+        <div class="controls">
+            <label class="checkbox">
+                <input type="checkbox" data-bind="checked: settings.plugins.octolightHA.turnOnPrintStart"> Turn on light on print start </label>
+        </div>
+    </div>
+    <div class="control-group">
+        <div class="controls">
+            <label class="checkbox">
+                <input type="checkbox" data-bind="checked: settings.plugins.octolightHA.turnOffPrintEnd"> Turn off light on print end </label>
+        </div>
+    </div>
+    <div class="control-group">
+        <div class="controls">
+            <label class="checkbox">
+                <input type="checkbox" data-bind="checked: settings.plugins.octolightHA.turnOffPrintFailure"> Turn off light on print failure </label>
+        </div>
+    </div>
+    <div class="control-group">
+        <div class="controls">
+            <label class="checkbox">
+                <input type="checkbox" data-bind="checked: settings.plugins.octolightHA.turnOffPrintCancellation"> Turn off light on print cancellation </label>
+        </div>
+    </div>
 </form>


### PR DESCRIPTION
Adds the option to turn light on when print starts, and off on print end/failure/cancellation.

![image](https://github.com/mark-bloom/OctoLight_Home-Assistant/assets/41117774/e5a4cd3e-39ae-4976-baf9-1022dbe0437d)
